### PR TITLE
fixed type error on test menu

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@ Change log
 
 3.2 (unreleased)
 ----------------
+- fixed type error on adding session items via  test menu
 
 
 3.1 (2021-01-01)

--- a/Products/mcdutils/sessiondata.py
+++ b/Products/mcdutils/sessiondata.py
@@ -60,13 +60,15 @@ class MemCacheSessionDataContainer(SimpleItem, PropertyManager):
         """ Add key value pairs from 'items' textarea to the session.
         """
         request = self.REQUEST
-        items = request.form.get('items', ())
+        items = request.form.get('items', [])
         session = request['SESSION']
 
         before = len(session)
         count = len(items)
 
         for line in items:
+            if not isinstance(line,bytes):
+                line = line.encode()
             k, v = line.split(b' ', 1)
             k = k.strip()
             v = v.strip()

--- a/Products/mcdutils/www/add_items.pt
+++ b/Products/mcdutils/www/add_items.pt
@@ -10,7 +10,11 @@
 
   <form class="mt-4 zmi-edit zmi-text zmi-ace-brief" 
     action="addItemsToSessionForm" method="POST">
-    <legend>Add Items to Session </legend>
+    <legend>Add Items to Session 
+      <span class="font-weight-normal">
+        as space-separated key-value pairs line by line
+      </span>
+    </legend>
     <textarea id="content" data-contenttype="text" 
       class="form-control zmi-zpt zmi-code col-sm-12" 
       name="items:lines"></textarea>


### PR DESCRIPTION
Hi @dataflake ,
manually entering key-value pairs for testing purposes (./www/add_items.pt) may end up in a bytes vs string error:

```
2021-09-02 16:48:31 ERROR [Zope.SiteErrorLog:252][waitress-0] 1630594111.65405730.8248992389087919 http://localhost:8081/memcache_session_data/addItemsToSessionForm
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 167, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 376, in publish_module
  Module ZPublisher.WSGIPublisher, line 271, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 68, in call_object
  Module Shared.DC.Scripts.Bindings, line 333, in __call__
  Module Shared.DC.Scripts.Bindings, line 370, in _bindAndExec
  Module Products.PageTemplates.PageTemplateFile, line 143, in _exec
  Module Products.PageTemplates.PageTemplate, line 81, in pt_render
  Module zope.pagetemplate.pagetemplate, line 133, in pt_render
  Module Products.PageTemplates.engine, line 365, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 307, in render
  Module chameleon.template, line 214, in render
  Module chameleon.utils, line 75, in raise_with_traceback
  Module chameleon.template, line 192, in render
  Module fab13edea965a28381b717234af08073, line 180, in render
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 221, in _eval
  Module Products.PageTemplates.Expressions, line 152, in render
  Module Products.mcdutils.sessiondata, line 70, in addItemsToSession
TypeError: must be str or None, not bytes

 - Expression: "context/addItemsToSession"
 - Filename:   addItemsToSessionForm
 - Location:   (line 5: col 22)
 - Arguments:  template: <PageTemplateFile at /memcache_session_data/add_items>
               here: <MemCacheSessionDataContainer at /memcache_session_data>
               context: <MemCacheSessionDataContainer at /memcache_session_data>
               container: <MemCacheSessionDataContainer at /memcache_session_data>
               nothing: None
               options: {'args': ()}
               root: <Application at >
               request: <WSGIRequest, URL=http://localhost:8081/memcache_session_data/addItemsToSessionForm>
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x7f7f91a44f70>
               user: <User 'admin'>
               default: <DEFAULT>
               repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x7f7f8b587a40>
               loop: {}
               target_language: None
               translate: <function BaseTemplate.render.<locals>.translate at 0x7f7f8b45d430>
               attrs: {'class': 'container-fluid'}
2021-09-02 16:48:31 ERROR [waitress:357][waitress-0] Exception while serving /memcache_session_data/addItemsToSessionForm
Traceback (most recent call last):
  File "/home/zope/vpy38/lib/python3.8/site-packages/chameleon/template.py", line 192, in render
    self._render(stream, econtext, rcontext)
  File "/home/zope/instance/zms5_gpoh/var/cache/fab13edea965a28381b717234af08073.py", line 180, in render
    __value = _static_140185799519392('path', 'context/addItemsToSession', econtext=econtext)(_static_140185799516608(econtext, __zt_tmp))
  File "/home/zope/vpy38/lib/python3.8/site-packages/zope/tales/expressions.py", line 250, in __call__
    return self._eval(econtext)
  File "/home/zope/src/zopefoundation/Zope/src/Products/PageTemplates/Expressions.py", line 221, in _eval
    return render(ob, econtext.vars)
  File "/home/zope/src/zopefoundation/Zope/src/Products/PageTemplates/Expressions.py", line 152, in render
    ob = ob()
  File "/home/zope/src/zopefoundation/Products.mcdutils/Products/mcdutils/sessiondata.py", line 70, in addItemsToSession
    k, v = line.split(b' ', 1)
TypeError: must be str or None, not bytes
```

To avoid this type error I added a condtion when splitting the key-value pair:

![mcdutils_test](https://user-images.githubusercontent.com/29705216/131882855-79a71681-d1e2-43b9-a945-1af407bab31f.gif)

Would be great if you take it over.
Many thanks
f

