### PR TITLE
Fixed in-operation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Change log
 
 5.1 (unreleased)
 ----------------
+- Ensure key 'passw' is treated as string for the 'in' check in ``__repr__``
 
 
 5.0 (2025-11-19)

--- a/src/Products/mcdutils/mapping.py
+++ b/src/Products/mcdutils/mapping.py
@@ -66,9 +66,19 @@ class MemCacheMapping(PersistentMapping):
         # the ZPublisher HTTPRequest class tries to do.
         new_dict = dict(self.data)
         for key in list(new_dict.keys()):
-            k_str = key.decode('utf-8', 'replace') if isinstance(key, bytes) else str(key)
+            k_str = (
+                key.decode("utf-8", "replace")
+                if isinstance(key, (bytes, bytearray))
+                else str(key)
+            )
             lower_key = k_str.lower()
-            if any(marker in lower_key for marker in ('passw', 'pwd', 'secret', 'token', 'cred')):
+            if any(
+                marker in lower_key for marker in (
+                    'passw', 
+                    'pwd', 
+                    'secret', 
+                    'token', 
+                    'cred')):
                 new_dict[key] = '<password obscured>'
         return repr(new_dict)
 

--- a/src/Products/mcdutils/mapping.py
+++ b/src/Products/mcdutils/mapping.py
@@ -65,8 +65,9 @@ class MemCacheMapping(PersistentMapping):
         # Overriding here to try and hide some password fields, like
         # the ZPublisher HTTPRequest class tries to do.
         new_dict = dict(self.data)
-        for key in new_dict.keys():
-            if 'passw' in key.lower():
+        for key in list(new_dict.keys()):
+            k_str = key.decode('utf-8', 'ignore') if isinstance(key, bytes) else str(key)
+            if 'passw' in k_str.lower():
                 new_dict[key] = '<password obscured>'
         return repr(new_dict)
 

--- a/src/Products/mcdutils/mapping.py
+++ b/src/Products/mcdutils/mapping.py
@@ -66,8 +66,9 @@ class MemCacheMapping(PersistentMapping):
         # the ZPublisher HTTPRequest class tries to do.
         new_dict = dict(self.data)
         for key in list(new_dict.keys()):
-            k_str = key.decode('utf-8', 'ignore') if isinstance(key, bytes) else str(key)
-            if 'passw' in k_str.lower():
+            k_str = key.decode('utf-8', 'replace') if isinstance(key, bytes) else str(key)
+            lower_key = k_str.lower()
+            if any(marker in lower_key for marker in ('passw', 'pwd', 'secret', 'token', 'cred')):
                 new_dict[key] = '<password obscured>'
         return repr(new_dict)
 

--- a/src/Products/mcdutils/mapping.py
+++ b/src/Products/mcdutils/mapping.py
@@ -74,10 +74,10 @@ class MemCacheMapping(PersistentMapping):
             lower_key = k_str.lower()
             if any(
                 marker in lower_key for marker in (
-                    'passw', 
-                    'pwd', 
-                    'secret', 
-                    'token', 
+                    'passw',
+                    'pwd',
+                    'secret',
+                    'token',
                     'cred')):
                 new_dict[key] = '<password obscured>'
         return repr(new_dict)


### PR DESCRIPTION
To avoid an error like:

```log
  File "/home/zope/vpy313/lib/python3.13/site-packages/Products/mcdutils/mapping.py", line 69, in __repr__
    if 'passw' in key.lower():
       ^^^^^^^^^^^^^^^^^^^^^^
TypeError: a bytes-like object is required, not 'str'
```
we may to force the key into string-type before applying the in-operator.
